### PR TITLE
Add CSV import and export

### DIFF
--- a/app/api/user/export/route.ts
+++ b/app/api/user/export/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { requireAuthenticatedUser, handleError } from "@/lib/server-utils";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   const userOrRes = await requireAuthenticatedUser();
   if (!("id" in userOrRes)) return userOrRes;
   try {
@@ -12,6 +12,40 @@ export async function GET() {
     });
     if (!user) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+    const format = new URL(req.url).searchParams.get("format");
+    if (format === "csv") {
+      const fields = [
+        "year",
+        "month",
+        "brutto_tax",
+        "brutto_av",
+        "brutto_pv",
+        "brutto_rv",
+        "brutto_kv",
+        "deduction_tax_income",
+        "deduction_tax_church",
+        "deduction_tax_solidarity",
+        "deduction_tax_other",
+        "social_av",
+        "social_pv",
+        "social_rv",
+        "social_kv",
+        "payout_netto",
+        "payout_transfer",
+        "payout_vwl",
+        "payout_other",
+      ] as const;
+      let csv = `${fields.join(",")},identifier,name,value\n`;
+      for (const s of user.statements) {
+        const stmtValues = fields.map((f) => (s as Record<string, unknown>)[f]);
+        for (const inc of s.incomes) {
+          csv += `${stmtValues.join(",")},${inc.identifier},${inc.name},${inc.value}\n`;
+        }
+      }
+      return new Response(csv, {
+        headers: { "Content-Type": "text/csv" },
+      });
     }
     return NextResponse.json(user);
   } catch (error) {

--- a/app/api/user/import/route.test.ts
+++ b/app/api/user/import/route.test.ts
@@ -78,4 +78,47 @@ describe("/api/user/import", () => {
     });
     expect(res.status).toBe(201);
   });
+
+  it("imports statements from csv", async () => {
+    mockRequire.mockResolvedValueOnce({ id: "u1" });
+    (prisma.statement.create as jest.Mock).mockResolvedValueOnce({ id: "s1" });
+    const csv =
+      "year,month,brutto_tax,brutto_av,brutto_pv,brutto_rv,brutto_kv,deduction_tax_income,deduction_tax_church,deduction_tax_solidarity,deduction_tax_other,social_av,social_pv,social_rv,social_kv,payout_netto,payout_transfer,payout_vwl,payout_other,identifier,name,value\n" +
+      "2024,1,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,id,n,5\n";
+    const req = new Request("http://localhost/api/user/import?format=csv", {
+      method: "POST",
+      body: csv,
+    });
+    const res = await POST(req as unknown as NextRequest);
+    expect(prisma.statement.deleteMany).toHaveBeenCalledWith({
+      where: { user_id: "u1" },
+    });
+    expect(prisma.statement.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        user_id: "u1",
+        month: 1,
+        year: 2024,
+        brutto_tax: 1,
+        brutto_av: 2,
+        brutto_pv: 3,
+        brutto_rv: 4,
+        brutto_kv: 5,
+        deduction_tax_income: 6,
+        deduction_tax_church: 7,
+        deduction_tax_solidarity: 8,
+        deduction_tax_other: 9,
+        social_av: 10,
+        social_pv: 11,
+        social_rv: 12,
+        social_kv: 13,
+        payout_netto: 14,
+        payout_transfer: 15,
+        payout_vwl: 16,
+        payout_other: 17,
+        incomes: { create: [{ name: "n", identifier: "id", value: 5 }] },
+      }),
+      include: { incomes: true },
+    });
+    expect(res.status).toBe(201);
+  });
 });

--- a/app/api/user/import/route.ts
+++ b/app/api/user/import/route.ts
@@ -2,20 +2,68 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { handleError, requireAuthenticatedUser } from "@/lib/server-utils";
 import { ensurePositiveStatement } from "@/lib/statement-utils";
+import { StatementData } from "@/constants/Interfaces";
 
-interface ImportedIncome extends Record<string, unknown> {
-  name: string;
-  identifier: string;
-  value: number;
-}
+type ImportedIncome = StatementData["incomes"][number] & Record<string, unknown>;
 
 export async function POST(req: NextRequest) {
   const userOrRes = await requireAuthenticatedUser();
   if (!("id" in userOrRes)) return userOrRes;
   try {
-    const body = await req.json();
-    const statements = Array.isArray(body?.statements) ? body.statements : [];
-    if (statements.length === 0) {
+    const format = new URL(req.url).searchParams.get("format");
+    let statements: unknown[] = [];
+    if (format === "csv") {
+      const text = await req.text();
+      const lines = text.trim().split(/\r?\n/);
+      const fields = [
+        "year",
+        "month",
+        "brutto_tax",
+        "brutto_av",
+        "brutto_pv",
+        "brutto_rv",
+        "brutto_kv",
+        "deduction_tax_income",
+        "deduction_tax_church",
+        "deduction_tax_solidarity",
+        "deduction_tax_other",
+        "social_av",
+        "social_pv",
+        "social_rv",
+        "social_kv",
+        "payout_netto",
+        "payout_transfer",
+        "payout_vwl",
+        "payout_other",
+      ] as const;
+      lines.shift();
+      const grouped: Record<string, Record<string, unknown> & { incomes: ImportedIncome[] }> = {};
+      for (const line of lines) {
+        if (!line) continue;
+        const parts = line.split(",");
+        const stmt: Record<string, unknown> = {};
+        fields.forEach((f, i) => {
+          const num = Number(parts[i]);
+          if (!Number.isNaN(num)) stmt[f] = num;
+        });
+        const identifier = parts[fields.length];
+        const name = parts[fields.length + 1];
+        const value = Number(parts[fields.length + 2]);
+        const year = Number(stmt.year);
+        const month = Number(stmt.month);
+        if (!year || !month || !identifier || !name) continue;
+        const key = `${year}-${month}`;
+        if (!grouped[key]) {
+          grouped[key] = { ...stmt, incomes: [] };
+        }
+        grouped[key].incomes.push({ identifier, name, value });
+      }
+      statements = Object.values(grouped);
+    } else {
+      const body = await req.json();
+      statements = Array.isArray(body?.statements) ? body.statements : [];
+    }
+    if (!Array.isArray(statements) || statements.length === 0) {
       return NextResponse.json({ error: "Ungültiges Format" }, { status: 400 });
     }
     // Remove all existing statements of the user before importing new ones
@@ -29,7 +77,7 @@ export async function POST(req: NextRequest) {
         user_id,
         userId,
         ...rest
-      } = ensurePositiveStatement(s);
+      } = ensurePositiveStatement(s as StatementData);
       void id;
       void user_id;
       void userId;

--- a/components/navigation/MenuContent.tsx
+++ b/components/navigation/MenuContent.tsx
@@ -70,6 +70,23 @@ export default function MenuContent() {
     }
   };
 
+  const handleExportCsv = async () => {
+    try {
+      const res = await fetch("/api/user/export?format=csv");
+      if (!res.ok) return;
+      const data = await res.text();
+      const blob = new Blob([data], { type: "text/csv" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "gehaltskompass-data.csv";
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      // ignore errors
+    }
+  };
+
   const handleImportClick = () => {
     fileInputRef.current?.click();
   };
@@ -87,11 +104,18 @@ export default function MenuContent() {
     }
     try {
       const text = await file.text();
-      const res = await fetch("/api/user/import", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: text,
-      });
+      const isCsv =
+        file.type === "text/csv" || file.name.toLowerCase().endsWith(".csv");
+      const res = await fetch(
+        `/api/user/import${isCsv ? "?format=csv" : ""}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": isCsv ? "text/csv" : "application/json",
+          },
+          body: text,
+        },
+      );
       if (res.ok) {
         location.reload();
       }
@@ -186,13 +210,16 @@ export default function MenuContent() {
           <Stack spacing={2} sx={{ pt: 1 }}>
             <input
               type="file"
-              accept="application/json"
+              accept="application/json,text/csv"
               hidden
               ref={fileInputRef}
               onChange={handleImportFile}
             />
             <Button variant="outlined" onClick={handleExport}>
               Daten exportieren
+            </Button>
+            <Button variant="outlined" onClick={handleExportCsv}>
+              CSV exportieren
             </Button>
             <Button variant="outlined" onClick={handleImportClick}>
               Daten importieren


### PR DESCRIPTION
## Summary
- support CSV format in user data export API
- parse and import statements from CSV files
- add CSV export button and support CSV import in settings menu
- include full statement data in CSV import/export
- replace remaining `any` casts in CSV import route with `StatementData`-based types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689635e92ae0832590549add390b6134